### PR TITLE
Create offsets-13.6.4.json

### DIFF
--- a/offsets/offsets-13.6.4.json
+++ b/offsets/offsets-13.6.4.json
@@ -1,0 +1,29 @@
+{
+  "gameTime": "0x3106B08",
+  "objIndex": "0x8",
+  "objTeam": "0x34",
+  "objNetworkID": "0xB4",
+  "objPosition": "0x1DC",
+  "objHealth": "0xE7C",
+  "objMaxHealth": "0xE8C",
+  "objMana": "0x029C",
+  "objMaxMana": "0x2AC",
+  "objName": "0x2B04",
+  "objLvl": "0x32FC",
+  "objExperience": "0x32EC",
+  "objCurrentGold": "0x1BB4",
+  "objTotalGold": "0x1BC4",
+  "objDisplayName": "0x54",
+  "objDisplayNameLength": "0x64",
+
+  "objectManager": "0x186E154",
+  "objectMapCount": "0x2C",
+  "objectMapRoot": "0x28",
+  "objectMapNodeNetId": "0x10",
+  "objectMapNodeObject": "0x14",
+
+  "heroList": "0x186E1F4",
+  "minionList": "0x24BB824",
+  "turretList": "0x310357C",
+  "inhibitorList": "0x310E0A4"
+}


### PR DESCRIPTION
I could validate most values as they did not change from 13.6.2, couldn't validate minion/inhibitor list.
Not sure if the version update is even necessary. Please do let me know if its not.