### PR TITLE
remove "async" from `index.d.ts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ declare module "@larseble/farsight" {
     objDisplayNameLength: number;
   }
 
-  export async function connectToLeague(): Promise<boolean>
+  export function connectToLeague(): Promise<boolean>
   export function disconnectFromLeague(): boolean
   export function makeSnapshot(): Snapshot
   export function setOffsets(offsets: Offsets): boolean


### PR DESCRIPTION
So I am getting this and it is preventing me from compiling my typescript project:
![image](https://github.com/floh22/native-farsight-module/assets/65524828/abd6eccd-eaa6-4c68-a992-296cc7638d5e)

Reading up on the issue, I have come to the conclusion that the fact that `connectToLeague` returns `Promise<boolean>` is all that is needed:
![image](https://github.com/floh22/native-farsight-module/assets/65524828/6ba3f417-3e67-481f-b577-33bbe37ee93d)

I suppose that this would just be a nice little fix.