### PR TITLE
Fix Memory Read Failure

### DIFF
--- a/src/unit/GameObject.cc
+++ b/src/unit/GameObject.cc
@@ -51,20 +51,24 @@ void GameObject::LoadFromMemory(DWORD64 base, HANDLE hProcess, bool deepLoad)
             name.resize(nameLength);
             memcpy(name.data(), &nameBuff[0], nameLength);
         }
+        try {
+            int displayNameLength = Memory::ReadDWORD64FromBuffer(buff, Offsets::ObjDisplayNameLength);
 
-        int displayNameLength = Memory::ReadDWORD64FromBuffer(buff, Offsets::ObjDisplayNameLength);
-
-        if (displayNameLength < 16)
-        {
-            displayName.resize(displayNameLength);
-            memcpy(displayName.data(), &buff[Offsets::ObjDisplayName], displayNameLength);
-        }
-        else
-        {
-            char displayNameBuff[50];
-            Memory::Read(hProcess, Memory::ReadDWORD64FromBuffer(buff, Offsets::ObjDisplayName), displayNameBuff, 50);
-            displayName.resize(displayNameLength);
-            memcpy(displayName.data(), &displayNameBuff[0], displayNameLength);
+            if (displayNameLength < 16)
+            {
+                displayName.resize(displayNameLength);
+                memcpy(displayName.data(), &buff[Offsets::ObjDisplayName], displayNameLength);
+            }
+            else
+            {
+                char displayNameBuff[50];
+                Memory::Read(hProcess, Memory::ReadDWORD64FromBuffer(buff, Offsets::ObjDisplayName), displayNameBuff, 50);
+                displayName.resize(displayNameLength);
+                memcpy(displayName.data(), &displayNameBuff[0], displayNameLength);
+            }
+        } catch (...) {
+            displayName.resize(5);
+            memcpy(displayName.data(), "N/A", 5);
         }
     }
 }


### PR DESCRIPTION
This pull request addresses an issue in the codebase where memory read failures on display names can cause a crash from Farsight. The proposed changes implement a solution by introducing a fallback mechanism to return "N/A" when memory read operations fail.

This pull request is related to the issue RCVolus/league-observer-tool#21, which outlines the problem and the need for this fix.