### PR TITLE
Added possibility to use axios instead of fetch module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 const addon = require('bindings')('farsight');
 
+// Uncomment this code to use axios instead of fetch.
+/*let axios = require("axios")
+let fetch = async (...args) => {
+    let res = await axios.get(...args)
+    return { ok: true, json: () => { return res.data } }
+}*/
+
 var offsetsSet = false;
 var championsSet = false;
 var connected = false;


### PR DESCRIPTION
There's now a dirty code you can uncomment to be able to use the program with the axios module instead of the fetch used originally.
